### PR TITLE
Add PyPi Publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,35 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This would add auto-publishing this package to PyPi so it is easily installable and able to be incorporated in other PyPI packages easily. This will publish a new version to PyPi on every release being made.

This PR does not work out of the box, as it needs a PyPi access token stored in `PYPI_API_TOKEN` in the repository secrets. 

For the OpenClimateFix repos, we first published a PyPi package manually and then after that initial publish, made an access token for that specific project that we then put in the repo secrets. 

The impetus for this PR is that PyPi will not allow packages to have git dependencies (https://github.com/openclimatefix/nowcasting_dataset/issues/137).

Happy to answer any questions or anything about this!