### PR TITLE
Add support for proxy connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 # PV_Live
 A Python implementation of the PV_Live web API. See https://www.solar.sheffield.ac.uk/pvlive/
 
-**Latest Version: 0.11**
+**Latest Version: 0.12**
 
-**New! Updated 2022-07-19 to use the v4 PV_Live API.**
+**New! Updated 2022-12-10 to provide support for proxy connections.**
 
 ## About this repository
 
@@ -94,17 +94,19 @@ This utility can be used to download data to a CSV file:
 
 ```
 >> pv_live -h
-usage: pvlive.py [-h] [-s "<yyyy-mm-dd HH:MM:SS>"] [-e "<yyyy-mm-dd HH:MM:SS>"] [--entity_type <entity_type>] [--entity_id <entity_id>]
-                 [--period <5|30>] [-q] [-o </path/to/output/file>]
+usage: pvlive.py [-h] [-s "<yyyy-mm-dd HH:MM:SS>"] [-e "<yyyy-mm-dd HH:MM:SS>"] [--entity_type <entity_type>]
+                 [--entity_id <entity_id>] [--period <5|30>] [-q] [-o </path/to/output/file>] [-p <proxies> <proxies>]
 
 This is a command line interface (CLI) for the PV_Live API module
 
 optional arguments:
   -h, --help            show this help message and exit
   -s "<yyyy-mm-dd HH:MM:SS>", --start "<yyyy-mm-dd HH:MM:SS>"
-                        Specify a UTC start date in 'yyyy-mm-dd HH:MM:SS' format (inclusive), default behaviour is to retrieve the latest outturn.
+                        Specify a UTC start date in 'yyyy-mm-dd HH:MM:SS' format (inclusive), default behaviour is to retrieve the
+                        latest outturn.
   -e "<yyyy-mm-dd HH:MM:SS>", --end "<yyyy-mm-dd HH:MM:SS>"
-                        Specify a UTC end date in 'yyyy-mm-dd HH:MM:SS' format (inclusive), default behaviour is to retrieve the latest outturn.
+                        Specify a UTC end date in 'yyyy-mm-dd HH:MM:SS' format (inclusive), default behaviour is to retrieve the
+                        latest outturn.
   --entity_type <entity_type>
                         Specify an entity type, either 'gsp' or 'pes'. Default is 'pes'.
   --entity_id <entity_id>
@@ -113,8 +115,11 @@ optional arguments:
   -q, --quiet           Specify to not print anything to stdout.
   -o </path/to/output/file>, --outfile </path/to/output/file>
                         Specify a CSV file to write results to.
+  -p <proxies> <proxies>, --proxies <proxies> <proxies>
+                        Proxy addresses in the order of http and https requests separated by a whitespace e.g. -p
+                        http://10.10.1.10:3128 http://10.10.1.10:1080
 
-Jamie Taylor, 2018-06-04
+Jamie Taylor & Ethan Jones, 2018-06-04
 ```
 
 ## Using the Docker Image

--- a/pvlive_api/pvlive.py
+++ b/pvlive_api/pvlive.py
@@ -7,6 +7,7 @@ A Python interface for the PV_Live web API from Sheffield Solar.
 - Updated: 2020-10-20 to return Pandas dataframe object
 - Updated: 2021-01-15 to use v3 of the PV_Live API and expose GSP endpoints as well as PES
 - Updated: 2022-07-19 to use v4 of the PV_Live API
+- Updated: 2022-10-12 to provide support for proxy connections.
 """
 
 import sys
@@ -14,14 +15,14 @@ import os
 import json
 from datetime import datetime, timedelta, date, time
 from time import sleep
-from typing import List, Union, Tuple
+from typing import List, Union, Tuple, Dict
 import inspect
+
 import pytz
 import requests
 import argparse
 from numpy import nan, int64
 import pandas as pd
-
 
 class PVLiveException(Exception):
     """An Exception specific to the PVLive class."""
@@ -35,7 +36,6 @@ class PVLiveException(Exception):
     def __str__(self):
         return self.msg
 
-
 class PVLive:
     """
     Interface with the PV_Live web API.
@@ -45,16 +45,23 @@ class PVLive:
     `retries` : int
         Optionally specify the number of retries to use should the API respond with anything
         other than status code 200. Exponential back-off applies inbetween retries.
+    `proxies` : Dict
+        Optionally specify a Dict of proxies for http and https requests in the format seen here:
+        https://requests.readthedocs.io/en/latest/user/advanced/#proxies i.e. {"http": "<address>",
+        "https": "<address>"}
     """
-    def __init__(self, retries: int = 3):
+    def __init__(self, proxies: Dict, retries: int = 3):
         self.base_url = "https://api0.solar.sheffield.ac.uk/pvlive/api/v4/"
         self.max_range = {"national": timedelta(days=365), "regional": timedelta(days=30)}
         self.retries = retries
+        self.requests_session = requests.Session()
+        if proxies is not None:
+            self.requests_session.proxies.update(proxies)
         self.gsp_list = self._get_gsp_list()
         self.pes_list = self._get_pes_list()
         self.gsp_ids = self.gsp_list.gsp_id.dropna().astype(int64).unique()
         self.pes_ids = self.pes_list.pes_id.dropna().astype(int64).unique()
-
+        
     def _get_gsp_list(self):
         """Fetch the GSP list from the API and convert to Pandas DataFrame."""
         url = f"{self.base_url}/gsp_list"
@@ -374,7 +381,7 @@ class PVLive:
         while not success and try_counter < self.retries + 1:
             try_counter += 1
             try:
-                page = requests.get(url)
+                page = self.requests_session.get(url)
                 page.raise_for_status()
                 success = True
             except requests.exceptions.HTTPError:
@@ -414,12 +421,11 @@ class PVLive:
             raise ValueError("The period parameter must be one of: "
                              f"{', '.join(map(str, periods))}.")
 
-
 def parse_options():
     """Parse command line options."""
     parser = argparse.ArgumentParser(description=("This is a command line interface (CLI) for the "
                                                   "PV_Live API module"),
-                                     epilog="Jamie Taylor, 2018-06-04")
+                                     epilog="Jamie Taylor & Ethan Jones, 2018-06-04")
     parser.add_argument("-s", "--start", metavar="\"<yyyy-mm-dd HH:MM:SS>\"", dest="start",
                         action="store", type=str, required=False, default=None,
                         help="Specify a UTC start date in 'yyyy-mm-dd HH:MM:SS' format "
@@ -444,6 +450,10 @@ def parse_options():
     parser.add_argument("-o", "--outfile", metavar="</path/to/output/file>", dest="outfile",
                         action="store", type=str, required=False,
                         help="Specify a CSV file to write results to.")
+    parser.add_argument('-p', '--proxies', metavar="<proxies>", dest="proxies",
+                        type=str, required=False, default=None, action="store", nargs=2,
+                        help="Proxy addresses in the order of http and https requests separated by "
+                             "a whitespace e.g. -p http://10.10.1.10:3128 http://10.10.1.10:1080")
     options = parser.parse_args()
 
     def handle_options(options):
@@ -471,14 +481,15 @@ def parse_options():
             except:
                 raise Exception("OptionsError: Failed to parse end datetime, make sure you use "
                                 "'yyyy-mm-dd HH:MM:SS' format.")
+        if options.proxies is not None:
+            options.proxies = {"http": options.proxies[0], "https": options.proxies[1]}
         return options
     return handle_options(options)
-
 
 def main():
     """Load CLI options and access the API accordingly."""
     options = parse_options()
-    pvl = PVLive()
+    pvl = PVLive(options.proxies)
     if options.start is None and options.end is None:
         data = pvl.latest(entity_type=options.entity_type, entity_id=options.entity_id,
                           extra_fields="installedcapacity_mwp", dataframe=True)
@@ -493,7 +504,6 @@ def main():
         data.to_csv(options.outfile, float_format="%.3f", index=False)
     if not options.quiet:
         print(data)
-
 
 if __name__ == "__main__":
     main()

--- a/pvlive_api_demo.py
+++ b/pvlive_api_demo.py
@@ -13,7 +13,6 @@ import pytz
 
 from pvlive_api import PVLive
 
-
 def main():
     """
     Demo API's functionality.
@@ -112,7 +111,6 @@ def main():
     print(pvlive.day_peak(date(2019, 3, 18), entity_type="gsp", entity_id=120, dataframe=True))
     print("\nGSP ID 120 cumulative generation on 2019-03-18: ")
     print(pvlive.day_energy(date(2019, 3, 18), entity_type="gsp", entity_id=120))
-
 
 if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="0.11",
+    version="0.12",
 
     description="A Python interface for the PV_Live web API from Sheffield Solar.",
     long_description=long_description,


### PR DESCRIPTION
As per #12 ; **adds support for proxy connections when making http or https requests** using the requests lib as seen here: https://requests.readthedocs.io/en/latest/user/advanced/#proxies

Includes:
- Updated command line interface to include option to add http and https proxies,
- Handling for the above arguments,
- Further implementation to update the requests session to use the passed-in proxies.
- Updated README and version number.

Doesn't include:
- Updated sphinx documentation - review before generating

cc: @JamieTaylor-TUOS 